### PR TITLE
Fix slow tag check in `FacadeItem#useOn`

### DIFF
--- a/src/main/java/com/portingdeadmods/cable_facades/content/items/FacadeItem.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/content/items/FacadeItem.java
@@ -39,7 +39,7 @@ public class FacadeItem extends Item {
             Block block = BuiltInRegistries.BLOCK.get(new ResourceLocation(tag.getString(FACADE_BLOCK)));
             Block targetBlock = p_41427_.getLevel().getBlockState(pos).getBlock();
 
-            if (!CFConfig.isBlockAllowed(targetBlock) && p_41427_.getLevel().getBlockState(pos).getTags().noneMatch(blockTag -> blockTag.equals(CFItemTags.SUPPORTS_FACADE))){
+            if (!CFConfig.isBlockAllowed(targetBlock) && !p_41427_.getLevel().getBlockState(pos).is(CFItemTags.SUPPORTS_FACADE)){
                 return InteractionResult.FAIL;
             }
 


### PR DESCRIPTION
`FacadeItem#useOn` checks whether the block right clicked on is in the `supports_facade` tag.
Currently, it does so by iterating over all tags the block is a part of and checking whether each tag is equal to the `supports_facade` tag. This is rather slow as it scales linearly with the number of tags the block is in.

This PR changes the check to use `BlockState#is` with the tag as an argument. This performs a single set lookup rather than comparing each tag.