### PR TITLE
Facade blockstates & Rotation! Fixes #23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,8 @@ gradle-app.setting
 
 **/build/
 
+bin
+
 # Common working directory
 run/
 runs/

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ mod_name=Cable Facades
 mod_license=MIT
 mod_version=1.1.5
 mod_group_id=com.portingdeadmods
-mod_authors=Leclowndu93150, Thepigcat76, SuperMartijn642
+mod_authors=Leclowndu93150, Thepigcat76, SuperMartijn642, Heather White
 mod_description= Adds facades for most cables in the game.
 
 ## Dependency Properties

--- a/src/main/java/com/portingdeadmods/cable_facades/content/items/FacadeItem.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/content/items/FacadeItem.java
@@ -12,6 +12,7 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.context.BlockPlaceContext;
 import net.minecraft.world.item.context.UseOnContext;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
@@ -59,7 +60,7 @@ public class FacadeItem extends Item {
                     return InteractionResult.FAIL;
                 }
 
-                FacadeUtils.addFacade(level, pos, block1.defaultBlockState());
+                FacadeUtils.addFacade(level, pos, block1.getStateForPlacement(new BlockPlaceContext(context)));
 
                 if (!context.getPlayer().isCreative() && CFConfig.consumeFacade) {
                     itemStack.shrink(1);

--- a/src/main/java/com/portingdeadmods/cable_facades/content/items/FacadeItem.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/content/items/FacadeItem.java
@@ -59,7 +59,7 @@ public class FacadeItem extends Item {
                     return InteractionResult.FAIL;
                 }
 
-                FacadeUtils.addFacade(level, pos, block1);
+                FacadeUtils.addFacade(level, pos, block1.defaultBlockState());
 
                 if (!context.getPlayer().isCreative() && CFConfig.consumeFacade) {
                     itemStack.shrink(1);

--- a/src/main/java/com/portingdeadmods/cable_facades/data/CableFacadeSavedData.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/data/CableFacadeSavedData.java
@@ -12,7 +12,6 @@ import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.saveddata.SavedData;
 import org.jetbrains.annotations.NotNull;
@@ -100,6 +99,7 @@ public class CableFacadeSavedData extends SavedData {
     }
 
     private static CableFacadeSavedData load(CompoundTag compoundTag, ServerLevel serverLevel) {
+        //TODO : Handle migration!
         DataResult<Pair<LevelFacadeMap, Tag>> dataResult = LevelFacadeMap.CODEC.decode(NbtOps.INSTANCE, compoundTag.get(ID));
         Optional<Pair<LevelFacadeMap, Tag>> mapTagPair = dataResult
                 .resultOrPartial(err -> CFMain.LOGGER.error("Decoding error: {}", err));

--- a/src/main/java/com/portingdeadmods/cable_facades/data/CableFacadeSavedData.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/data/CableFacadeSavedData.java
@@ -13,6 +13,7 @@ import net.minecraft.nbt.Tag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.saveddata.SavedData;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -25,7 +26,7 @@ import java.util.Optional;
  * <br>
  * Internally it uses a hashmap that maps {@link ChunkPos} to {@link ChunkFacadeMap}
  * <br>
- * {@link ChunkFacadeMap} maps individual {@link BlockPos}itions to {@link Block}
+ * {@link ChunkFacadeMap} maps individual {@link BlockPos}itions to {@link BlockState}
  */
 public class CableFacadeSavedData extends SavedData {
     public static final String ID = "cable_facades_saved_data";
@@ -67,8 +68,8 @@ public class CableFacadeSavedData extends SavedData {
         return getFacadeMapForChunk(chunkPos);
     }
 
-    public void addFacade(BlockPos blockPos, Block block) {
-        getOrCreateFacadeMapForPos(blockPos).getChunkMap().put(blockPos, block);
+    public void addFacade(BlockPos blockPos, BlockState blockState) {
+        getOrCreateFacadeMapForPos(blockPos).getChunkMap().put(blockPos, blockState);
         setDirty();
     }
 
@@ -81,7 +82,7 @@ public class CableFacadeSavedData extends SavedData {
         return this.levelFacadeMap.getChunkFacadeMaps().isEmpty();
     }
 
-    public @Nullable Block getFacade(BlockPos blockPos) {
+    public @Nullable BlockState getFacade(BlockPos blockPos) {
         ChunkFacadeMap facadeMapForPos = getFacadeMapForPos(blockPos);
         if (facadeMapForPos != null) {
             return facadeMapForPos.getChunkMap().get(blockPos);

--- a/src/main/java/com/portingdeadmods/cable_facades/data/helper/ChunkFacadeMap.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/data/helper/ChunkFacadeMap.java
@@ -4,7 +4,6 @@ import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.portingdeadmods.cable_facades.utils.CodecUtils;
 import net.minecraft.core.BlockPos;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.AbstractMap;
@@ -14,7 +13,7 @@ import java.util.stream.Collectors;
 
 public class ChunkFacadeMap {
     public static final Codec<ChunkFacadeMap> CODEC = RecordCodecBuilder.create(builder -> builder.group(
-            Codec.unboundedMap(Codec.STRING, CodecUtils.BLOCK_CODEC).fieldOf("chunk_map").forGetter(ChunkFacadeMap::chunkMapToString)
+            Codec.unboundedMap(Codec.STRING, CodecUtils.BLOCKSTATE_CODEC).fieldOf("chunk_map").forGetter(ChunkFacadeMap::chunkMapToString)
     ).apply(builder, ChunkFacadeMap::chunkMapFromString));
 
     private final Map<BlockPos, BlockState> chunkMap;
@@ -35,13 +34,13 @@ public class ChunkFacadeMap {
         return getChunkMap().isEmpty();
     }
 
-    private static ChunkFacadeMap chunkMapFromString(Map<String, Block> chunkFacade) {
+    private static ChunkFacadeMap chunkMapFromString(Map<String, BlockState> chunkFacade) {
         return new ChunkFacadeMap(chunkFacade.entrySet().stream()
                 .map(entry -> new AbstractMap.SimpleEntry<>(BlockPos.of(Long.parseLong(entry.getKey())), entry.getValue()))
                 .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
     }
 
-    private Map<String, Block> chunkMapToString() {
+    private Map<String, BlockState> chunkMapToString() {
         return getChunkMap().entrySet().stream()
                 .map(entry -> new AbstractMap.SimpleEntry<>(String.valueOf(entry.getKey().asLong()), entry.getValue()))
                 .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));

--- a/src/main/java/com/portingdeadmods/cable_facades/data/helper/ChunkFacadeMap.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/data/helper/ChunkFacadeMap.java
@@ -5,6 +5,7 @@ import com.mojang.serialization.codecs.RecordCodecBuilder;
 import com.portingdeadmods.cable_facades.utils.CodecUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.AbstractMap;
 import java.util.HashMap;
@@ -16,17 +17,17 @@ public class ChunkFacadeMap {
             Codec.unboundedMap(Codec.STRING, CodecUtils.BLOCK_CODEC).fieldOf("chunk_map").forGetter(ChunkFacadeMap::chunkMapToString)
     ).apply(builder, ChunkFacadeMap::chunkMapFromString));
 
-    private final Map<BlockPos, Block> chunkMap;
+    private final Map<BlockPos, BlockState> chunkMap;
 
     public ChunkFacadeMap() {
         this.chunkMap = new HashMap<>();
     }
 
-    public ChunkFacadeMap(Map<BlockPos, Block> chunkMap) {
+    public ChunkFacadeMap(Map<BlockPos, BlockState> chunkMap) {
         this.chunkMap = chunkMap;
     }
 
-    public Map<BlockPos, Block> getChunkMap() {
+    public Map<BlockPos, BlockState> getChunkMap() {
         return chunkMap;
     }
 

--- a/src/main/java/com/portingdeadmods/cable_facades/data/helper/LevelFacadeMap.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/data/helper/LevelFacadeMap.java
@@ -14,6 +14,11 @@ public class LevelFacadeMap {
             Codec.unboundedMap(Codec.STRING, ChunkFacadeMap.CODEC).fieldOf("chunks_map").forGetter(LevelFacadeMap::levelFacadeMapToString)
     ).apply(builder, LevelFacadeMap::levelFacadeMapFromString));
 
+    //This codec will be used to attempt migration
+    public static final Codec<LevelFacadeMap> MIGRATION_CODEC = RecordCodecBuilder.create(builder -> builder.group(
+            Codec.unboundedMap(Codec.STRING, ChunkFacadeMap.MIGRATION_CODEC).fieldOf("chunks_map").forGetter(LevelFacadeMap::levelFacadeMapToString)
+    ).apply(builder, LevelFacadeMap::levelFacadeMapFromString));
+
     private final Map<ChunkPos, ChunkFacadeMap> chunkFacadeMaps;
 
     public LevelFacadeMap() {

--- a/src/main/java/com/portingdeadmods/cable_facades/events/ClientFacadeManager.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/events/ClientFacadeManager.java
@@ -2,7 +2,8 @@ package com.portingdeadmods.cable_facades.events;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
@@ -11,7 +12,7 @@ import java.util.Map;
 
 public final class ClientFacadeManager {
     // Blocks in the currently loaded chunks. Updated whenever a chunk is loaded or unloaded by this player
-    public static Map<BlockPos, @Nullable Block> FACADED_BLOCKS = new HashMap<>();
+    public static Map<BlockPos, @Nullable BlockState> FACADED_BLOCKS = new HashMap<>();
     // Map to keep track of what blockpositions are in which chunks
     public static final Map<ChunkPos, List<BlockPos>> LOADED_BLOCKS = new HashMap<>();
 }

--- a/src/main/java/com/portingdeadmods/cable_facades/events/GameClientEvents.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/events/GameClientEvents.java
@@ -21,7 +21,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.BlockHitResult;
@@ -74,14 +73,14 @@ public final class GameClientEvents {
             return;
         }
 
-        Map<BlockPos, @Nullable Block> chunkFacades = ClientFacadeManager.FACADED_BLOCKS;
+        Map<BlockPos, @Nullable BlockState> chunkFacades = ClientFacadeManager.FACADED_BLOCKS;
         if (chunkFacades == null || chunkFacades.isEmpty()) {
             return;
         }
 
         // Capture all facades which are actually visible
         Frustum frustum = event.getFrustum();
-        List<Map.Entry<BlockPos, Block>> visibleFacades = chunkFacades.entrySet().stream()
+        List<Map.Entry<BlockPos, BlockState>> visibleFacades = chunkFacades.entrySet().stream()
                 .filter(entry -> {
                     if (entry == null) return false;
                     BlockPos pos = entry.getKey();
@@ -111,13 +110,12 @@ public final class GameClientEvents {
         poseStack.translate(-cameraPos.x, -cameraPos.y, -cameraPos.z);
 
         // Render all the facades to the buffer
-        for (Map.Entry<BlockPos, Block> entry : visibleFacades) {
+        for (Map.Entry<BlockPos, BlockState> entry : visibleFacades) {
             BlockPos pos = entry.getKey();
-            Block facadeBlock = entry.getValue();
-            if (pos == null || facadeBlock == null) {
+            BlockState facadeState = entry.getValue();
+            if (pos == null || facadeState == null) {
                 continue;
             }
-            BlockState facadeState = facadeBlock.defaultBlockState();
 
             // Get the model and model data for the facade
             BlockRenderDispatcher blockRenderer = mc.getBlockRenderer();

--- a/src/main/java/com/portingdeadmods/cable_facades/events/GameEvents.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/events/GameEvents.java
@@ -25,6 +25,7 @@ import net.minecraft.world.level.block.HorizontalDirectionalBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.block.state.properties.Half;
+import net.minecraft.world.level.block.state.properties.SlabType;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
@@ -99,6 +100,7 @@ public final class GameEvents {
                     //This, in vanilla, is technically explicit support for stairs - but should play nicely with modded blocks too.
                     if (facadeState.hasProperty(BlockStateProperties.HALF) && direction == Direction.WEST) {
                         Half half = facadeState.getValue(BlockStateProperties.HALF);
+                        //Inverts the HALF.
                         newFacadeState = newFacadeState.setValue(BlockStateProperties.HALF, half == Half.BOTTOM ? Half.TOP : Half.BOTTOM);
                     }
                                    
@@ -120,6 +122,17 @@ public final class GameEvents {
                     //Readding the facade is a simple easy way to update it both in the chunkmap and for clients.
                     FacadeUtils.removeFacade(level, pos);
                     FacadeUtils.addFacade(level, pos, newFacadeState);
+                }
+
+                //Basically explicit slab support. But it works on anything utilising SLAB_TYPE
+                else if (facadeState.hasProperty(BlockStateProperties.SLAB_TYPE)) {
+                    SlabType slab = facadeState.getValue(BlockStateProperties.SLAB_TYPE);
+                    //Inverts the SlabType.
+                    BlockState newFacadeState = facadeState.setValue(BlockStateProperties.SLAB_TYPE, nextSlab(slab));
+                    //Readding the facade is a simple easy way to update it both in the chunkmap and for clients.
+                    FacadeUtils.removeFacade(level, pos);
+                    FacadeUtils.addFacade(level, pos, newFacadeState);
+
                 }
 
             }
@@ -173,6 +186,14 @@ public final class GameEvents {
             case WEST -> Direction.UP;
             //Impossible to hit...
             default -> direction;
+        };
+    }
+
+    private static SlabType nextSlab(SlabType slab) {
+        return switch(slab) {
+            case BOTTOM -> SlabType.TOP;
+            case TOP -> SlabType.DOUBLE;
+            case DOUBLE -> SlabType.BOTTOM;
         };
     }
 }

--- a/src/main/java/com/portingdeadmods/cable_facades/events/GameEvents.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/events/GameEvents.java
@@ -153,21 +153,15 @@ public final class GameEvents {
     //TODO: Possibly move to another spot?
     //Used to rotate a direction more nicely, as the default order when allowing for up / down would feel clunky.
     private static Direction rotate(Direction direction) {
-        switch (direction) {
-            case DOWN:
-                return Direction.NORTH;
-            case EAST:
-                return Direction.SOUTH;
-            case NORTH:
-                return Direction.EAST;
-            case SOUTH:
-                return Direction.WEST;
-            case UP:
-                return Direction.DOWN;
-            case WEST:
-                return Direction.UP;            
-        }
-        //Impossible to hit..
-        return direction;
+        return switch(direction) {
+            case DOWN -> Direction.NORTH;
+            case EAST -> Direction.SOUTH;
+            case NORTH -> Direction.EAST;
+            case SOUTH -> Direction.WEST;
+            case UP -> Direction.DOWN;
+            case WEST -> Direction.UP;
+            //Impossible to hit...
+            default -> direction;
+        };
     }
 }

--- a/src/main/java/com/portingdeadmods/cable_facades/events/GameEvents.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/events/GameEvents.java
@@ -23,6 +23,8 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.DirectionalBlock;
 import net.minecraft.world.level.block.HorizontalDirectionalBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+import net.minecraft.world.level.block.state.properties.Half;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
@@ -90,9 +92,18 @@ public final class GameEvents {
                 //But this would work with a furnace, chest etc as-is.
 
                 if (facadeState.hasProperty(HorizontalDirectionalBlock.FACING)) {
-                    Direction direction = facadeState.getValue(HorizontalDirectionalBlock.FACING);                   
+                    Direction direction = facadeState.getValue(HorizontalDirectionalBlock.FACING);    
+                    //Init variable here so we can adjust it as we see fit when checking things like stairs and slabs.
+                    BlockState newFacadeState = facadeState;
+                    
+                    //This, in vanilla, is technically explicit support for stairs - but should play nicely with modded blocks too.
+                    if (facadeState.hasProperty(BlockStateProperties.HALF) && direction == Direction.WEST) {
+                        Half half = facadeState.getValue(BlockStateProperties.HALF);
+                        newFacadeState = newFacadeState.setValue(BlockStateProperties.HALF, half == Half.BOTTOM ? Half.TOP : Half.BOTTOM);
+                    }
+                                   
                     //We only need to rotate the block horizontally here, so this works well.
-                    BlockState newFacadeState = facadeState.setValue(HorizontalDirectionalBlock.FACING, direction.getClockWise());
+                    newFacadeState = newFacadeState.setValue(HorizontalDirectionalBlock.FACING, direction.getClockWise());
 
                     //Readding the facade is a simple easy way to update it both in the chunkmap and for clients.
                     FacadeUtils.removeFacade(level, pos);

--- a/src/main/java/com/portingdeadmods/cable_facades/events/GameEvents.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/events/GameEvents.java
@@ -56,10 +56,11 @@ public final class GameEvents {
         Player player = event.getEntity();
         Level level = event.getLevel();
         BlockPos pos = event.getPos();
+        InteractionHand hand = event.getHand();
 
         BlockState facadeState = FacadeUtils.getFacade(level, pos);
         if (player.isShiftKeyDown()
-                && player.getMainHandItem().is(CFItemTags.WRENCHES)
+                && player.getItemInHand(hand).is(CFItemTags.WRENCHES)
                 && facadeState != null) {
             if (!level.isClientSide()) {
                 FacadeUtils.removeFacade(level, pos);
@@ -73,13 +74,13 @@ public final class GameEvents {
                 }
 
             }
-            player.swing(InteractionHand.MAIN_HAND);
+            player.swing(hand);
 
             updateBlocks(level, pos);
             event.setCanceled(true);
 
         }
-        else if (player.getMainHandItem().is(CFItemTags.WRENCHES)
+        else if (player.getItemInHand(hand).is(CFItemTags.WRENCHES)
             && facadeState != null) {
             //Rotation!
             if (!level.isClientSide()) {
@@ -98,7 +99,7 @@ public final class GameEvents {
                 }
 
             }
-            player.swing(InteractionHand.MAIN_HAND);
+            player.swing(hand);
 
             updateBlocks(level, pos);
             event.setCanceled(true);

--- a/src/main/java/com/portingdeadmods/cable_facades/events/GameEvents.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/events/GameEvents.java
@@ -19,7 +19,6 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;

--- a/src/main/java/com/portingdeadmods/cable_facades/events/GameEvents.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/events/GameEvents.java
@@ -38,10 +38,10 @@ public final class GameEvents {
 
         if (!level.isClientSide()) {
             if (FacadeUtils.hasFacade(level, pos)) {
-                Block facade = FacadeUtils.getFacade(level, pos);
+                BlockState facade = FacadeUtils.getFacade(level, pos);
                 FacadeUtils.removeFacade(level, pos);
                 if (!player.isCreative()) {
-                    ItemStack facadeStack = CFItems.FACADE.get().createFacade(facade);
+                    ItemStack facadeStack = CFItems.FACADE.get().createFacade(facade.getBlock());
                     Containers.dropItemStack(level, pos.getX(), pos.getY(), pos.getZ(), facadeStack);
                 }
                 event.setCanceled(true);
@@ -56,7 +56,7 @@ public final class GameEvents {
         Level level = event.getLevel();
         BlockPos pos = event.getPos();
 
-        Block facadeBlock = FacadeUtils.getFacade(level, pos);
+        BlockState facadeBlock = FacadeUtils.getFacade(level, pos);
         if (player.isShiftKeyDown()
                 && player.getMainHandItem().is(CFItemTags.WRENCHES)
                 && facadeBlock != null) {
@@ -64,7 +64,7 @@ public final class GameEvents {
                 FacadeUtils.removeFacade(level, pos);
 
                 if (!player.isCreative()) {
-                    ItemStack facadeStack = CFItems.FACADE.get().createFacade(facadeBlock);
+                    ItemStack facadeStack = CFItems.FACADE.get().createFacade(facadeBlock.getBlock());
                     Containers.dropItemStack(level, pos.getX(), pos.getY(), pos.getZ(), facadeStack);
                 } else {
                     level.playSound(null, player.getX(), player.getY() + 0.5, player.getZ(),
@@ -78,6 +78,8 @@ public final class GameEvents {
             event.setCanceled(true);
 
         }
+
+        //TODO: When not crouching, is this when we handle rotation?
 
     }
 

--- a/src/main/java/com/portingdeadmods/cable_facades/mixins/BlockMixin.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/mixins/BlockMixin.java
@@ -34,9 +34,9 @@ public abstract class BlockMixin {
         if (sidePos.equals(FACADE_CHECK_MARKER)) {
             BlockPos relativePos = pos.relative(side);
             if (ClientFacadeManager.FACADED_BLOCKS != null && ClientFacadeManager.FACADED_BLOCKS.containsKey(relativePos)) {
-                Block facade = ClientFacadeManager.FACADED_BLOCKS.get(relativePos);
+                BlockState facade = ClientFacadeManager.FACADED_BLOCKS.get(relativePos);
                 if (facade != null) {
-                    return facade.defaultBlockState();
+                    return facade;
                 }
             }
         }
@@ -60,7 +60,7 @@ public abstract class BlockMixin {
 
         try {
             if (ClientFacadeManager.FACADED_BLOCKS != null && ClientFacadeManager.FACADED_BLOCKS.containsKey(sidePos)) {
-                Block facade = ClientFacadeManager.FACADED_BLOCKS.get(sidePos);
+                BlockState facade = ClientFacadeManager.FACADED_BLOCKS.get(sidePos);
                 if (facade != null) {
                     boolean shouldRender = safeCheckFaceRendering(state, level, pos, side);
                     ci.setReturnValue(shouldRender);

--- a/src/main/java/com/portingdeadmods/cable_facades/mixins/BlockStateBaseMixin.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/mixins/BlockStateBaseMixin.java
@@ -42,9 +42,9 @@ public abstract class BlockStateBaseMixin {
                 if (!blockState.is(getBlock())) {
                     if (level instanceof ServerLevel serverLevel) {
                         CableFacadeSavedData helper = CableFacadeSavedData.get(serverLevel);
-                        Block facadeBlock = helper.getFacade(blockPos);
-                        if (facadeBlock != null) {
-                            ItemStack facadeStack = CFItems.FACADE.get().createFacade(facadeBlock);
+                        BlockState facadeState = helper.getFacade(blockPos);
+                        if (facadeState != null) {
+                            ItemStack facadeStack = CFItems.FACADE.get().createFacade(facadeState.getBlock());
                             FacadeUtils.removeFacade(level, blockPos);
 
                             Containers.dropItemStack(level, blockPos.getX(), blockPos.getY(), blockPos.getZ(), facadeStack);
@@ -68,9 +68,9 @@ public abstract class BlockStateBaseMixin {
         cable_facades$recursionGuard.set(true);
         try {
             if (FacadeUtils.hasFacade(blockGetter, blockPos)) {
-                Block camoBlock = FacadeUtils.getFacade(blockGetter, blockPos);
-                if (camoBlock != null) {
-                    cir.setReturnValue(camoBlock.defaultBlockState().getCollisionShape(blockGetter, BlockPos.ZERO, collisionContext));
+                BlockState camoState = FacadeUtils.getFacade(blockGetter, blockPos);
+                if (camoState != null) {
+                    cir.setReturnValue(camoState.getCollisionShape(blockGetter, BlockPos.ZERO, collisionContext));
                 }
             }
         } finally {
@@ -88,9 +88,9 @@ public abstract class BlockStateBaseMixin {
         cable_facades$recursionGuard.set(true);
         try {
             if (FacadeUtils.hasFacade(blockGetter, blockPos)) {
-                Block camoBlock = FacadeUtils.getFacade(blockGetter, blockPos);
-                if (camoBlock != null) {
-                    cir.setReturnValue(camoBlock.defaultBlockState().getShape(blockGetter, BlockPos.ZERO, collisionContext));
+                BlockState camoState = FacadeUtils.getFacade(blockGetter, blockPos);
+                if (camoState != null) {
+                    cir.setReturnValue(camoState.getShape(blockGetter, BlockPos.ZERO, collisionContext));
                 }
             }
         } finally {
@@ -108,9 +108,9 @@ public abstract class BlockStateBaseMixin {
         cable_facades$recursionGuard.set(true);
         try {
             if (FacadeUtils.hasFacade(blockGetter, blockPos)) {
-                Block camoBlock = FacadeUtils.getFacade(blockGetter, blockPos);
-                if (camoBlock != null) {
-                    cir.setReturnValue(camoBlock.defaultBlockState().getOcclusionShape(blockGetter, BlockPos.ZERO));
+                BlockState camoState = FacadeUtils.getFacade(blockGetter, blockPos);
+                if (camoState != null) {
+                    cir.setReturnValue(camoState.getOcclusionShape(blockGetter, BlockPos.ZERO));
                 }
             }
         } finally {
@@ -128,9 +128,9 @@ public abstract class BlockStateBaseMixin {
         cable_facades$recursionGuard.set(true);
         try {
             if (FacadeUtils.hasFacade(blockGetter, blockPos)) {
-                Block camoBlock = FacadeUtils.getFacade(blockGetter, blockPos);
-                if (camoBlock != null) {
-                    cir.setReturnValue(camoBlock.defaultBlockState().getLightBlock(blockGetter, BlockPos.ZERO));
+                BlockState camoState = FacadeUtils.getFacade(blockGetter, blockPos);
+                if (camoState != null) {
+                    cir.setReturnValue(camoState.getLightBlock(blockGetter, BlockPos.ZERO));
                 }
             }
         } finally {
@@ -148,9 +148,9 @@ public abstract class BlockStateBaseMixin {
         cable_facades$recursionGuard.set(true);
         try {
             if (FacadeUtils.hasFacade(blockGetter, blockPos)) {
-                Block camoBlock = FacadeUtils.getFacade(blockGetter, blockPos);
-                if (camoBlock != null) {
-                    cir.setReturnValue(camoBlock.defaultBlockState().propagatesSkylightDown(blockGetter, BlockPos.ZERO));
+                BlockState camoState = FacadeUtils.getFacade(blockGetter, blockPos);
+                if (camoState != null) {
+                    cir.setReturnValue(camoState.propagatesSkylightDown(blockGetter, BlockPos.ZERO));
                 }
             }
         } finally {
@@ -168,9 +168,9 @@ public abstract class BlockStateBaseMixin {
         cable_facades$recursionGuard.set(true);
         try {
             if (FacadeUtils.hasFacade(blockGetter, blockPos)) {
-                Block camoBlock = FacadeUtils.getFacade(blockGetter, blockPos);
-                if (camoBlock != null) {
-                    cir.setReturnValue(camoBlock.defaultBlockState().isSolidRender(blockGetter, BlockPos.ZERO));
+                BlockState camoState = FacadeUtils.getFacade(blockGetter, blockPos);
+                if (camoState != null) {
+                    cir.setReturnValue(camoState.isSolidRender(blockGetter, BlockPos.ZERO));
                 }
             }
         } finally {

--- a/src/main/java/com/portingdeadmods/cable_facades/mixins/BlockStateBaseMixin.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/mixins/BlockStateBaseMixin.java
@@ -68,9 +68,9 @@ public abstract class BlockStateBaseMixin {
         cable_facades$recursionGuard.set(true);
         try {
             if (FacadeUtils.hasFacade(blockGetter, blockPos)) {
-                BlockState camoState = FacadeUtils.getFacade(blockGetter, blockPos);
-                if (camoState != null) {
-                    cir.setReturnValue(camoState.getCollisionShape(blockGetter, BlockPos.ZERO, collisionContext));
+                BlockState facadeState = FacadeUtils.getFacade(blockGetter, blockPos);
+                if (facadeState != null) {
+                    cir.setReturnValue(facadeState.getCollisionShape(blockGetter, BlockPos.ZERO, collisionContext));
                 }
             }
         } finally {
@@ -88,9 +88,9 @@ public abstract class BlockStateBaseMixin {
         cable_facades$recursionGuard.set(true);
         try {
             if (FacadeUtils.hasFacade(blockGetter, blockPos)) {
-                BlockState camoState = FacadeUtils.getFacade(blockGetter, blockPos);
-                if (camoState != null) {
-                    cir.setReturnValue(camoState.getShape(blockGetter, BlockPos.ZERO, collisionContext));
+                BlockState facadeState = FacadeUtils.getFacade(blockGetter, blockPos);
+                if (facadeState != null) {
+                    cir.setReturnValue(facadeState.getShape(blockGetter, BlockPos.ZERO, collisionContext));
                 }
             }
         } finally {
@@ -108,9 +108,9 @@ public abstract class BlockStateBaseMixin {
         cable_facades$recursionGuard.set(true);
         try {
             if (FacadeUtils.hasFacade(blockGetter, blockPos)) {
-                BlockState camoState = FacadeUtils.getFacade(blockGetter, blockPos);
-                if (camoState != null) {
-                    cir.setReturnValue(camoState.getOcclusionShape(blockGetter, BlockPos.ZERO));
+                BlockState facadeState = FacadeUtils.getFacade(blockGetter, blockPos);
+                if (facadeState != null) {
+                    cir.setReturnValue(facadeState.getOcclusionShape(blockGetter, BlockPos.ZERO));
                 }
             }
         } finally {
@@ -128,9 +128,9 @@ public abstract class BlockStateBaseMixin {
         cable_facades$recursionGuard.set(true);
         try {
             if (FacadeUtils.hasFacade(blockGetter, blockPos)) {
-                BlockState camoState = FacadeUtils.getFacade(blockGetter, blockPos);
-                if (camoState != null) {
-                    cir.setReturnValue(camoState.getLightBlock(blockGetter, BlockPos.ZERO));
+                BlockState facadeState = FacadeUtils.getFacade(blockGetter, blockPos);
+                if (facadeState != null) {
+                    cir.setReturnValue(facadeState.getLightBlock(blockGetter, BlockPos.ZERO));
                 }
             }
         } finally {
@@ -148,9 +148,9 @@ public abstract class BlockStateBaseMixin {
         cable_facades$recursionGuard.set(true);
         try {
             if (FacadeUtils.hasFacade(blockGetter, blockPos)) {
-                BlockState camoState = FacadeUtils.getFacade(blockGetter, blockPos);
-                if (camoState != null) {
-                    cir.setReturnValue(camoState.propagatesSkylightDown(blockGetter, BlockPos.ZERO));
+                BlockState facadeState = FacadeUtils.getFacade(blockGetter, blockPos);
+                if (facadeState != null) {
+                    cir.setReturnValue(facadeState.propagatesSkylightDown(blockGetter, BlockPos.ZERO));
                 }
             }
         } finally {
@@ -168,9 +168,9 @@ public abstract class BlockStateBaseMixin {
         cable_facades$recursionGuard.set(true);
         try {
             if (FacadeUtils.hasFacade(blockGetter, blockPos)) {
-                BlockState camoState = FacadeUtils.getFacade(blockGetter, blockPos);
-                if (camoState != null) {
-                    cir.setReturnValue(camoState.isSolidRender(blockGetter, BlockPos.ZERO));
+                BlockState facadeState = FacadeUtils.getFacade(blockGetter, blockPos);
+                if (facadeState != null) {
+                    cir.setReturnValue(facadeState.isSolidRender(blockGetter, BlockPos.ZERO));
                 }
             }
         } finally {

--- a/src/main/java/com/portingdeadmods/cable_facades/mixins/BlockStateMixin.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/mixins/BlockStateMixin.java
@@ -32,9 +32,9 @@ public abstract class BlockStateMixin extends BlockBehaviour.BlockStateBase impl
         cable_facades$recursionGuard.set(true);
         try {
             if (ClientFacadeManager.FACADED_BLOCKS.containsKey(pos)) {
-                BlockState camoState = ClientFacadeManager.FACADED_BLOCKS.get(pos);
-                if (camoState != null) {
-                    return camoState.getBlock().getAppearance(camoState, blockGetter, pos, side, queryState, queryPos);
+                BlockState facadeState = ClientFacadeManager.FACADED_BLOCKS.get(pos);
+                if (facadeState != null) {
+                    return facadeState.getBlock().getAppearance(facadeState, blockGetter, pos, side, queryState, queryPos);
                 }
             }
             return getBlock().getAppearance(this.asState(), blockGetter, pos, side, queryState, queryPos);
@@ -49,9 +49,9 @@ public abstract class BlockStateMixin extends BlockBehaviour.BlockStateBase impl
         cable_facades$recursionGuard.set(true);
         try {
             if (FacadeUtils.hasFacade(blockGetter, pos)) {
-                BlockState camoState = FacadeUtils.getFacade(blockGetter, pos);
-                if (camoState != null) {
-                    return camoState.getLightEmission();
+                BlockState facadeState = FacadeUtils.getFacade(blockGetter, pos);
+                if (facadeState != null) {
+                    return facadeState.getLightEmission();
                 }
             }
             return getBlock().getLightEmission(this.asState(), blockGetter, pos);

--- a/src/main/java/com/portingdeadmods/cable_facades/mixins/BlockStateMixin.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/mixins/BlockStateMixin.java
@@ -33,9 +33,8 @@ public abstract class BlockStateMixin extends BlockBehaviour.BlockStateBase impl
         cable_facades$recursionGuard.set(true);
         try {
             if (ClientFacadeManager.FACADED_BLOCKS.containsKey(pos)) {
-                Block camoBlock = ClientFacadeManager.FACADED_BLOCKS.get(pos);
-                if (camoBlock != null) {
-                    BlockState camoState = camoBlock.defaultBlockState();
+                BlockState camoState = ClientFacadeManager.FACADED_BLOCKS.get(pos);
+                if (camoState != null) {
                     return camoState.getBlock().getAppearance(camoState, blockGetter, pos, side, queryState, queryPos);
                 }
             }
@@ -51,9 +50,9 @@ public abstract class BlockStateMixin extends BlockBehaviour.BlockStateBase impl
         cable_facades$recursionGuard.set(true);
         try {
             if (FacadeUtils.hasFacade(blockGetter, pos)) {
-                Block camoBlock = FacadeUtils.getFacade(blockGetter, pos);
-                if (camoBlock != null) {
-                    return camoBlock.defaultBlockState().getLightEmission();
+                BlockState camoState = FacadeUtils.getFacade(blockGetter, pos);
+                if (camoState != null) {
+                    return camoState.getLightEmission();
                 }
             }
             return getBlock().getLightEmission(this.asState(), blockGetter, pos);

--- a/src/main/java/com/portingdeadmods/cable_facades/mixins/BlockStateMixin.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/mixins/BlockStateMixin.java
@@ -6,7 +6,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.level.BlockAndTintGetter;
 import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockBehaviour;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.common.extensions.IBlockStateExtension;

--- a/src/main/java/com/portingdeadmods/cable_facades/networking/s2c/AddFacadePayload.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/networking/s2c/AddFacadePayload.java
@@ -9,22 +9,22 @@ import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 
-public record AddFacadePayload(BlockPos facadePos, Block block) implements CustomPacketPayload {
+public record AddFacadePayload(BlockPos facadePos, BlockState blockState) implements CustomPacketPayload {
     public static final Type<AddFacadePayload> TYPE = new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath(CFMain.MODID, "add_facade"));
     public static final StreamCodec<RegistryFriendlyByteBuf, AddFacadePayload> STREAM_CODEC = StreamCodec.composite(
             BlockPos.STREAM_CODEC,
             AddFacadePayload::facadePos,
-            CodecUtils.BLOCK_STREAM_CODEC,
-            AddFacadePayload::block,
+            CodecUtils.BLOCKSTATE_STREAM_CODEC,
+            AddFacadePayload::blockState,
             AddFacadePayload::new
     );
 
     public boolean handle(IPayloadContext context) {
         context.enqueueWork(() -> {
-            ClientFacadeManager.FACADED_BLOCKS.put(facadePos, block);
+            ClientFacadeManager.FACADED_BLOCKS.put(facadePos, blockState);
             ClientFacadeUtils.updateBlocks(this.facadePos);
         });
         return true;

--- a/src/main/java/com/portingdeadmods/cable_facades/networking/s2c/AddFacadedBlocksPayload.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/networking/s2c/AddFacadedBlocksPayload.java
@@ -10,16 +10,16 @@ import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public record AddFacadedBlocksPayload(ChunkPos chunkPos,
-                                      Map<BlockPos, Block> facadedBlocks) implements CustomPacketPayload {
+                                      Map<BlockPos, BlockState> facadedBlocks) implements CustomPacketPayload {
     public static final Type<AddFacadedBlocksPayload> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(CFMain.MODID, "add_facaded_blocks"));
-    private static final StreamCodec<RegistryFriendlyByteBuf, Map<BlockPos, Block>> FACADED_BLOCKS_STREAM_CODEC = ByteBufCodecs.map(HashMap::new, BlockPos.STREAM_CODEC, CodecUtils.BLOCK_STREAM_CODEC);
+    private static final StreamCodec<RegistryFriendlyByteBuf, Map<BlockPos, BlockState>> FACADED_BLOCKS_STREAM_CODEC = ByteBufCodecs.map(HashMap::new, BlockPos.STREAM_CODEC, CodecUtils.BLOCKSTATE_STREAM_CODEC);
     public static final StreamCodec<RegistryFriendlyByteBuf, AddFacadedBlocksPayload> STREAM_CODEC = StreamCodec.composite(
             CodecUtils.CHUNK_POS_STREAM_CODEC,
             AddFacadedBlocksPayload::chunkPos,

--- a/src/main/java/com/portingdeadmods/cable_facades/utils/CodecUtils.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/utils/CodecUtils.java
@@ -2,31 +2,38 @@ package com.portingdeadmods.cable_facades.utils;
 
 import com.mojang.serialization.Codec;
 import io.netty.buffer.ByteBuf;
-import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.nbt.NbtUtils;
+import net.minecraft.nbt.TagParser;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.ChunkPos;
-import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
 
 public class CodecUtils {
-    public static final Codec<Block> BLOCK_CODEC = registryCodec(BuiltInRegistries.BLOCK);
-    public static final StreamCodec<ByteBuf, Block> BLOCK_STREAM_CODEC = registryStreamCodec(BuiltInRegistries.BLOCK);
+    public static final Codec<BlockState> BLOCKSTATE_CODEC = blockStateCodec();
+    public static final StreamCodec<ByteBuf, BlockState> BLOCKSTATE_STREAM_CODEC = blockStateStreamCodec();
 
     public static final StreamCodec<ByteBuf, ChunkPos> CHUNK_POS_STREAM_CODEC = ByteBufCodecs.VAR_LONG.map(ChunkPos::new, ChunkPos::toLong);
 
     /**
-     * Returns a codec using the resource location of the registry
+     * Returns a codec using NBT as a helper
      */
-    public static <T> Codec<T> registryCodec(Registry<T> registry) {
-        return ResourceLocation.CODEC.xmap(registry::get, registry::getKey);
+    public static Codec<BlockState> blockStateCodec() {
+        return TagParser.LENIENT_CODEC.xmap(
+            (state) -> NbtUtils.readBlockState(BuiltInRegistries.BLOCK.asLookup(), state),
+            NbtUtils::writeBlockState
+        );
     }
 
     /**
-     * Returns a stream codec using the resource location of the registry
+     * Returns a stream codec using NBT as a helper
      */
-    public static <T> StreamCodec<ByteBuf, T> registryStreamCodec(Registry<T> registry) {
-        return ResourceLocation.STREAM_CODEC.map(registry::get, registry::getKey);
+    public static StreamCodec<ByteBuf, BlockState> blockStateStreamCodec() {
+        return ByteBufCodecs.COMPOUND_TAG.map(
+            (state) -> NbtUtils.readBlockState(BuiltInRegistries.BLOCK.asLookup(), state),
+            NbtUtils::writeBlockState
+        );
     }
+
 }

--- a/src/main/java/com/portingdeadmods/cable_facades/utils/CodecUtils.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/utils/CodecUtils.java
@@ -2,19 +2,39 @@ package com.portingdeadmods.cable_facades.utils;
 
 import com.mojang.serialization.Codec;
 import io.netty.buffer.ByteBuf;
+import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.NbtUtils;
 import net.minecraft.nbt.TagParser;
 import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class CodecUtils {
+    public static final Codec<Block> BLOCK_CODEC = registryCodec(BuiltInRegistries.BLOCK);
+    public static final StreamCodec<ByteBuf, Block> BLOCK_STREAM_CODEC = registryStreamCodec(BuiltInRegistries.BLOCK);
+    
     public static final Codec<BlockState> BLOCKSTATE_CODEC = blockStateCodec();
     public static final StreamCodec<ByteBuf, BlockState> BLOCKSTATE_STREAM_CODEC = blockStateStreamCodec();
 
     public static final StreamCodec<ByteBuf, ChunkPos> CHUNK_POS_STREAM_CODEC = ByteBufCodecs.VAR_LONG.map(ChunkPos::new, ChunkPos::toLong);
+
+    /**
+     * Returns a codec using the resource location of the registry
+     */
+    public static <T> Codec<T> registryCodec(Registry<T> registry) {
+        return ResourceLocation.CODEC.xmap(registry::get, registry::getKey);
+    }
+
+    /**
+     * Returns a stream codec using the resource location of the registry
+     */
+    public static <T> StreamCodec<ByteBuf, T> registryStreamCodec(Registry<T> registry) {
+        return ResourceLocation.STREAM_CODEC.map(registry::get, registry::getKey);
+    }
 
     /**
      * Returns a codec using NBT as a helper

--- a/src/main/java/com/portingdeadmods/cable_facades/utils/FacadeUtils.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/utils/FacadeUtils.java
@@ -9,7 +9,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.neoforged.neoforge.network.PacketDistributor;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/com/portingdeadmods/cable_facades/utils/FacadeUtils.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/utils/FacadeUtils.java
@@ -20,17 +20,17 @@ public class FacadeUtils {
     }
 
     @Nullable
-    public static Block getFacade(BlockGetter level, BlockPos pos) {
+    public static BlockState getFacade(BlockGetter level, BlockPos pos) {
         if (level instanceof ServerLevel serverLevel) {
             return CableFacadeSavedData.get(serverLevel).getFacade(pos);
         }
         return ClientFacadeManager.FACADED_BLOCKS.get(pos);
     }
 
-    public static void addFacade(Level level, BlockPos pos, Block block) {
+    public static void addFacade(Level level, BlockPos pos, BlockState blockState) {
         if (level instanceof ServerLevel serverLevel) {
-            CableFacadeSavedData.get(serverLevel).addFacade(pos, block);
-            PacketDistributor.sendToPlayersTrackingChunk(serverLevel, new ChunkPos(pos), new AddFacadePayload(pos, block));
+            CableFacadeSavedData.get(serverLevel).addFacade(pos, blockState);
+            PacketDistributor.sendToPlayersTrackingChunk(serverLevel, new ChunkPos(pos), new AddFacadePayload(pos, blockState));
         }
     }
 


### PR DESCRIPTION
Changes facades to utilise BlockStates instead of Blocks, and adds support for rotation of already placed facades.
All functionality for placing new facades currently remains the same.


As part of this, I require credit - both ingame and on CF, with the latter being fine either in the authors list (preferable) or just in the description.
I'm not expecting a revenue cut (though I certainly wouldn't complain.)