### PR TITLE
Create build action

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,40 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
+
+name: Build
+
+on:
+  [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
+    # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v4 
+
+    - name: Build with Gradle Wrapper
+      run: ./gradlew build
+    
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: CableFacade-${{ github.run_id }}
+        path: build/libs/*.jar


### PR DESCRIPTION
It will auto build mod jar file on push or pull request. Users can use the latest mod without building on their computer.
I have tested it on my [fork](https://github.com/Forever-178/Cable-Facades/actions).