### PR TITLE
Improve right-click behavior of facades and wrenches

### DIFF
--- a/src/main/java/com/portingdeadmods/cable_facades/content/items/FacadeItem.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/content/items/FacadeItem.java
@@ -8,6 +8,7 @@ import com.portingdeadmods.cable_facades.utils.FacadeUtils;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
@@ -34,10 +35,27 @@ public class FacadeItem extends Item {
         if (!level.isClientSide()) {
             if (!FacadeUtils.hasFacade(level, pos)) {
                 Optional<Block> block = itemStack.get(CFDataComponents.FACADE_BLOCK);
-                if (block.isEmpty()) {
-                    return InteractionResult.FAIL;
+
+                ItemStack offhandItemStack = null;
+                Block block1;
+                if(block.isEmpty()){
+                    // If the player is holding an empty facade in their mainhand
+                    // and a block in their offhand, try to use that block.
+                    if (context.getHand() == InteractionHand.MAIN_HAND) {
+                        ItemStack offhand = context.getPlayer().getItemInHand(InteractionHand.OFF_HAND);
+                        Item item = offhand.getItem();
+                        if (item instanceof BlockItem blockItem) {
+                            offhandItemStack = offhand;
+                            block1 = blockItem.getBlock();
+                        } else {
+                            return InteractionResult.FAIL;
+                        }
+                    } else {
+                        return InteractionResult.FAIL;
+                    }
+                } else {
+                    block1 = block.get();
                 }
-                Block block1 = block.get();
 
                 Block targetBlock = context.getLevel().getBlockState(pos).getBlock();
 
@@ -50,10 +68,10 @@ public class FacadeItem extends Item {
 
                 // Prevent block from being facaded with itself or if it's disallowed
                 if (targetBlock == block1 || CFConfig.isBlockDisallowed(block1)) {
-                    if(targetBlock == block1){
-                        context.getPlayer().displayClientMessage(Component.translatable("cable_facades.error.cannot_facade_itself").withStyle(ChatFormatting.RED),true);
+                    if (targetBlock == block1) {
+                        context.getPlayer().displayClientMessage(Component.translatable("cable_facades.error.cannot_facade_itself").withStyle(ChatFormatting.RED), true);
                     } else {
-                        context.getPlayer().displayClientMessage(Component.translatable("cable_facades.error.block_disabled").withStyle(ChatFormatting.RED),true);
+                        context.getPlayer().displayClientMessage(Component.translatable("cable_facades.error.block_disabled").withStyle(ChatFormatting.RED), true);
                     }
                     return InteractionResult.FAIL;
                 }
@@ -62,6 +80,9 @@ public class FacadeItem extends Item {
 
                 if (!context.getPlayer().isCreative() && CFConfig.consumeFacade) {
                     itemStack.shrink(1);
+                    if(offhandItemStack != null){
+                        offhandItemStack.shrink(1);
+                    }
                 }
             }
         }

--- a/src/main/java/com/portingdeadmods/cable_facades/events/server/ServerInGameEvents.java
+++ b/src/main/java/com/portingdeadmods/cable_facades/events/server/ServerInGameEvents.java
@@ -63,10 +63,18 @@ public final class ServerInGameEvents {
         BlockPos pos = event.getPos();
         InteractionHand hand = event.getHand();
 
+        if(player.isShiftKeyDown() && hand == InteractionHand.OFF_HAND && player.getItemInHand(InteractionHand.MAIN_HAND).is(CFItemTags.WRENCHES)){
+            // If we're holding a wrench in our main hand, don't try to do anything with the offhand.
+            event.setCanceled(true);
+        }
+
         BlockState facadeState = FacadeUtils.getFacade(level, pos);
-        if (player.isShiftKeyDown()
-                && player.getItemInHand(hand).is(CFItemTags.WRENCHES)
-                && facadeState != null) {
+
+        // This event isn't relevant to us if there's no facade or we're not holding a wrench.
+        if(facadeState == null || !player.getItemInHand(hand).is(CFItemTags.WRENCHES)) return;
+
+        if (player.isShiftKeyDown()) {
+            // Remove facade!
             if (!level.isClientSide()) {
                 FacadeUtils.removeFacade(level, pos);
 
@@ -77,16 +85,8 @@ public final class ServerInGameEvents {
                     level.playSound(null, player.getX(), player.getY() + 0.5, player.getZ(),
                             SoundEvents.ITEM_PICKUP, SoundSource.PLAYERS, 0.2F, ((level.random.nextFloat() - level.random.nextFloat()) * 0.7F + 1.0F) * 2.0F);
                 }
-
             }
-            player.swing(hand);
-
-            updateBlocks(level, pos);
-            event.setCanceled(true);
-
-        }
-        else if (player.getItemInHand(hand).is(CFItemTags.WRENCHES)
-            && facadeState != null) {
+        } else {
             //Rotation!
             if (!level.isClientSide()) {
                 
@@ -133,17 +133,13 @@ public final class ServerInGameEvents {
                     //Readding the facade is a simple easy way to update it both in the chunkmap and for clients.
                     FacadeUtils.removeFacade(level, pos);
                     FacadeUtils.addFacade(level, pos, newFacadeState);
-
                 }
-
             }
-            player.swing(hand);
-
-            updateBlocks(level, pos);
-            event.setCanceled(true);
         }
 
-
+        player.swing(hand);
+        updateBlocks(level, pos);
+        event.setCanceled(true);
     }
 
     public static void updateBlocks(Level level, BlockPos pos) {


### PR DESCRIPTION
This PR encompasses three changes:

- ~~Toggling facade transparency is moved from the FacadeWrench item to an item tag, so it can be overriden and extended to include other wrench items.~~
- Prevent placing blocks from the offhand while holding a wrench item. This allows the player to hold a block in their offhand, and remove a facade without placing that block.
- Add a new behavior to empty facades where holding a block in the off-hand will use that block as the facade material. This matches how Create's copycats work.